### PR TITLE
Fixing #129

### DIFF
--- a/app/src/components/users/UserEditView.vue
+++ b/app/src/components/users/UserEditView.vue
@@ -115,13 +115,16 @@
 import { ref, watch, computed, onMounted } from "vue";
 import { useUserStore } from "../../stores/userStore.js";
 import { useRoute, useRouter } from 'vue-router';
+import { useGlobalDialogStore } from "../../stores/globalDialogStore.js";
 import FieldInput from "../inputs/FieldInput.vue";
 import UserNameInput from "./UserNameInput.vue";
 import SecretDialog from "./SecretDialog.vue";
+import { formatOrgErrors } from "../../errors/errors.js";
 
 const userStore = useUserStore();
 const route = useRoute();
 const router = useRouter();
+const dialogStore = useGlobalDialogStore();
 
 const editableFields = computed(() => {
   let fields = [
@@ -174,14 +177,25 @@ async function load() {
 
 async function saveChanges() {
   try {
+    const updatedUsername = localUser.value.username;
+    const orgShortName = localUser.value.org.short_name;
+
     await userStore.updateUser(oldUser.value.username, localUser.value);
-    resetForm();
     await router.replace({
       name: "SingleUserView",
-      params: { shortname: localUser.value.org.short_name, identifier: localUser.value.username },
+      params: { shortname: orgShortName, identifier: updatedUsername },
     });
-  } catch (err) {
-    console.log(err);
+  } catch (error) {
+    const data = error.response?.data;
+    if (data?.errors?.length || data?.error) {
+      const html = formatOrgErrors(data, "html");
+      dialogStore.error(html, "Update Failed", true);
+    } else {
+      dialogStore.error(
+        data?.message ?? error.message ?? "An unexpected error occurred.",
+        "Update Failed",
+      );
+    }
   }
 }
 

--- a/app/src/stores/userStore.js
+++ b/app/src/stores/userStore.js
@@ -114,19 +114,14 @@ export const useUserStore = defineStore("user", {
       };
     },
 
-    async updateUser(username, { org, ...body }) {
+    async updateUser(
+      username,
+      { org, created_by, created, last_updated, ...body },
+    ) {
       const { api } = useNetworkManager();
-      try {
-        await api.put(
-          `/registry/org/${org.short_name}/user/${username}`,
-          body,
-          {
-            headers: useAuthStore().headers,
-          },
-        );
-      } catch (error) {
-        console.error("Error updating user:", error);
-      }
+      await api.put(`/registry/org/${org.short_name}/user/${username}`, body, {
+        headers: useAuthStore().headers,
+      });
     },
 
     async deleteUser(identifier) {

--- a/app/tests/end_to_end/create_user_own_org.spec.js
+++ b/app/tests/end_to_end/create_user_own_org.spec.js
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { createApprovalWorkflowState, WorkflowActions } from "./actions";
 
 test.describe.configure({ mode: "serial" });
@@ -41,6 +41,75 @@ test("Org admin can create a user in their own org", async ({ page }) => {
 
   await actions.loginAsOrgAdmin();
   await actions.createUserFromUsersViewAndCaptureToken();
+});
+
+test("Org admin can rename a user in their own org", async ({ page }) => {
+  const actions = actionsFor(page);
+  const oldUsername = state.orgUser.username;
+  const newUsername = `renamed_${state.runId}@example.com`;
+
+  await actions.loginAsOrgAdmin();
+
+  await page.goto(`/org/${state.org.shortName}/user/${oldUsername}`);
+  await expect(
+    page.getByRole("heading", {
+      name: `${state.orgUser.firstName} ${state.orgUser.lastName}`,
+    }),
+  ).toBeVisible();
+  await expect(
+    page.locator(".v-card").filter({ hasText: "User" }),
+  ).toContainText(oldUsername);
+
+  await page.getByRole("button", { name: "Edit User" }).click();
+  await expect(page).toHaveURL(
+    (url) =>
+      url.pathname === `/org/${state.org.shortName}/user/${oldUsername}/edit`,
+  );
+
+  const usernameInput = page.getByRole("textbox", {
+    name: "Username",
+  });
+  await expect(usernameInput).toHaveValue(oldUsername);
+  await usernameInput.fill(newUsername);
+
+  const [updateRequest] = await Promise.all([
+    page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return (
+        request.method() === "PUT" &&
+        url.pathname.endsWith(
+          `/api/registry/org/${state.org.shortName}/user/${oldUsername}`,
+        )
+      );
+    }),
+    page.waitForResponse((response) => {
+      const url = new URL(response.url());
+      return (
+        response.request().method() === "PUT" &&
+        url.pathname.endsWith(
+          `/api/registry/org/${state.org.shortName}/user/${oldUsername}`,
+        ) &&
+        response.ok()
+      );
+    }),
+    page.waitForURL(
+      (url) =>
+        url.pathname === `/org/${state.org.shortName}/user/${newUsername}`,
+    ),
+    page.getByRole("button", { name: /^save$/i }).click(),
+  ]);
+
+  const updateBody = updateRequest.postDataJSON();
+  expect(updateBody).not.toHaveProperty("created_by");
+  expect(updateBody).not.toHaveProperty("created");
+  expect(updateBody).not.toHaveProperty("last_updated");
+  expect(updateBody).toHaveProperty("username", newUsername);
+
+  await expect(
+    page.locator(".v-card").filter({ hasText: "User" }),
+  ).toContainText(newUsername);
+
+  state.orgUser.username = newUsername;
 });
 
 test("Created org user can log in", async ({ page }) => {


### PR DESCRIPTION
Description
This PR fixes the user edit flow when changing a username.

Changes include:

Updates users through the original username endpoint while sending the new username in the request body.
Removes server-managed fields from the update payload: created_by, created, and last_updated.
Surfaces update API errors through the global dialog using the shared error formatter.
Redirects to the new username route after a successful username change.
Adds E2E coverage for renaming an org user, including request payload assertions and follow-up login with the renamed user.

fixes #129