### PR TITLE
Partner number format and defaults

### DIFF
--- a/app/src/assets/countries.js
+++ b/app/src/assets/countries.js
@@ -212,7 +212,7 @@ export const countryList = [
   { name: "Sweden", code: "SE" },
   { name: "Switzerland", code: "CH" },
   { name: "Syrian Arab Republic", code: "SY" },
-  { name: "Taiwan, Province of China", code: "TW" },
+  { name: "Taiwan", code: "TW" },
   { name: "Tajikistan", code: "TJ" },
   { name: "Tanzania, United Republic of", code: "TZ" },
   { name: "Thailand", code: "TH" },

--- a/app/src/components/inputs/FieldInput.vue
+++ b/app/src/components/inputs/FieldInput.vue
@@ -57,7 +57,7 @@
       <!-- Array (generic) -->
       <v-combobox
         v-else-if="field.type === 'array'"
-        v-model="model"
+        :model-value="model"
         :label="inputLabel"
         :aria-label="label"
         :required="field.required"
@@ -74,6 +74,7 @@
         validate-on="input"
         :delimiters="[',']"
         :rules="rules"
+        @update:model-value="updateArrayModel"
       />
 
       <v-select
@@ -253,6 +254,34 @@ const model = computed({
 });
 
 const rules = computed(() => getFieldRules(props.field));
+
+function toArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value === null || value === undefined || value === "") return [];
+  return [value];
+}
+
+function updateArrayModel(value) {
+  if (!props.field.maxSelections) {
+    model.value = value;
+    return;
+  }
+
+  const selected = toArray(value);
+  if (selected.length === 0) {
+    model.value = [];
+    return;
+  }
+
+  if (props.field.maxSelections === 1) {
+    const previous = toArray(model.value);
+    const added = selected.find((item) => !previous.includes(item));
+    model.value = [added ?? selected.at(-1)];
+    return;
+  }
+
+  model.value = selected.slice(0, props.field.maxSelections);
+}
 
 function resolveItem(id) {
   const key = props.field.itemValueKey ?? "uuid";

--- a/app/src/components/inputs/validators.js
+++ b/app/src/components/inputs/validators.js
@@ -3,6 +3,8 @@ const PHONE_RE = /^\+?[\d\s\-().]{7,20}$/;
 const URI_RE =
   /^https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{2,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)$/i;
 const USERNAME_RE = /^[A-Za-z0-9\-_@.]{3,128}$/;
+const PARTNER_NUMBER_RE =
+  /^(CNA|CNALR|ROOT|ADP|BULK_DOWNLOAD|SECRETARIAT)-[1-9]\d{3}-(?!0000)\d{4}$/;
 
 export const validatorFns = {
   email:
@@ -55,6 +57,13 @@ export const validatorFns = {
         return `${label} may only contain letters, numbers, and - _ @ .`;
       return true;
     },
+
+  partnerNumber:
+    (label = "Value") =>
+    (v) =>
+      !v ||
+      PARTNER_NUMBER_RE.test(v) ||
+      `${label} must use format AUTHORITY-YYYY-XXXX with authority CNA, CNALR, ROOT, ADP, BULK_DOWNLOAD, or SECRETARIAT; year 1000-9999; counter 0001-9999`,
 };
 
 export function getFieldRules(field) {

--- a/app/src/components/organizations/OrgUtils.js
+++ b/app/src/components/organizations/OrgUtils.js
@@ -59,6 +59,7 @@ export const baseOrgSchema = {
     label: "Authority",
     required: false,
     multiple: true,
+    maxSelections: 1,
     items: orgTypes,
     secretariatOnly: false,
     requiresApproval: true,
@@ -92,6 +93,7 @@ export const baseOrgSchema = {
     required: false,
     secretariatOnly: true,
     requiresApproval: true,
+    validator: { name: "partnerNumber" },
   },
   aliases: {
     type: "array",

--- a/app/src/components/organizations/OrganizationListView.vue
+++ b/app/src/components/organizations/OrganizationListView.vue
@@ -415,7 +415,7 @@ const headerOverrides = [
     filterType: "select",
     exportable: false,
   },
-  { key: "aliases", sortable: false, visible: true, filterType: "text" },
+  { key: "aliases", sortable: false, visible: false, filterType: "text" },
   { key: "authority", sortable: false, visible: true },
   {
     title: "User Count",
@@ -532,11 +532,7 @@ function refreshHeaderTitles() {
   }
 }
 
-watch(
-  () => glossaryStore.glossary.terms,
-  refreshHeaderTitles,
-  { deep: true },
-);
+watch(() => glossaryStore.glossary.terms, refreshHeaderTitles, { deep: true });
 
 const websitesNeedUpdating = computed(
   () =>

--- a/app/src/components/organizations/OrganizationsCreatePage.vue
+++ b/app/src/components/organizations/OrganizationsCreatePage.vue
@@ -23,7 +23,7 @@
                   :field="getField(key, overrides)"
                   :model-value="organization[key]"
                   show-help-hint
-                  @update:model-value="organization[key] = $event"
+                  @update:model-value="updateField(key, $event)"
                 />
               </v-col>
             </v-row>
@@ -47,7 +47,7 @@
                 :field="getField(key, overrides)"
                 :model-value="organization[key]"
                 show-help-hint
-                @update:model-value="organization[key] = $event"
+                @update:model-value="updateField(key, $event)"
               />
             </v-col>
           </v-row>
@@ -72,7 +72,7 @@
 </template>
 
 <script setup>
-import { ref, computed, watch } from "vue";
+import { ref, computed, onMounted, watch } from "vue";
 import { useRouter } from "vue-router";
 
 // Stores
@@ -106,10 +106,19 @@ const auth = useAuthStore();
 const dialogStore = useGlobalDialogStore();
 
 const form = ref(null);
+const partnerNumberManuallyEdited = ref(false);
+const partnerNumberAuthorities = [
+  "CNA",
+  "CNALR",
+  "ROOT",
+  "ADP",
+  "BULK_DOWNLOAD",
+  "SECRETARIAT",
+];
 
 const orgItems = computed(() =>
   orgStore.orgs.orgs.filter((org) =>
-    org.authority.every((a) => a !== "SECRETARIAT" && a !== "ROOT"),
+    org.authority?.every((a) => a !== "SECRETARIAT" && a !== "ROOT"),
   ),
 );
 
@@ -141,14 +150,53 @@ function defaultProgramData() {
   };
 }
 
+function partnerNumberAuthority(authority = []) {
+  const selected = Array.isArray(authority) ? authority : [authority];
+  return selected.find((a) => partnerNumberAuthorities.includes(a)) ?? null;
+}
+
+function nextPartnerNumber(authority = []) {
+  const prefix = partnerNumberAuthority(authority);
+  if (!prefix) return null;
+
+  const year = String(new Date().getFullYear());
+  const matcher = new RegExp(`^${prefix}-${year}-([0-9]{4})$`);
+  const maxCounter = orgStore.orgs.orgs.reduce((max, org) => {
+    const match = org.partner_number?.match(matcher);
+    if (!match) return max;
+
+    const counter = Number(match[1]);
+    if (counter < 1 || counter > 9999) return max;
+    return Math.max(max, counter);
+  }, 0);
+
+  if (maxCounter >= 9999) return null;
+  return `${prefix}-${year}-${String(maxCounter + 1).padStart(4, "0")}`;
+}
+
 const defaultEmpty = () => ({
   authority: ["CNA"],
+  partner_number: auth.isSecretariat ? nextPartnerNumber(["CNA"]) : null,
   contact_info: emptyPrivateContacts(),
   private_contacts: [],
   program_data: auth.isSecretariat ? defaultProgramData() : {},
 });
 
 const organization = ref(defaultEmpty());
+
+function applyDefaultPartnerNumber() {
+  if (!auth.isSecretariat || partnerNumberManuallyEdited.value) return;
+  organization.value.partner_number = nextPartnerNumber(
+    organization.value.authority,
+  );
+}
+
+function updateField(key, value) {
+  if (key === "partner_number") {
+    partnerNumberManuallyEdited.value = true;
+  }
+  organization.value[key] = value;
+}
 
 const visibleSections = computed(() => {
   const schemaKeys = new Set(
@@ -181,6 +229,18 @@ watch(
   },
   { immediate: true },
 );
+
+watch(
+  () => organization.value.authority,
+  () => applyDefaultPartnerNumber(),
+  { deep: true },
+);
+
+onMounted(async () => {
+  if (!auth.isSecretariat) return;
+  await orgStore.fetchOrgs();
+  applyDefaultPartnerNumber();
+});
 
 async function createOrg() {
   const { valid } = await form.value.validate();
@@ -253,6 +313,7 @@ watch(
 );
 
 function resetForm() {
+  partnerNumberManuallyEdited.value = false;
   organization.value = defaultEmpty();
   form.value?.resetValidation();
 }


### PR DESCRIPTION
feat(orgs): refine organization form validation and defaults
- add partner number validation with allowed authority prefixes
- default partner number from selected authority, current year, and next counter
- keep authority values as arrays while limiting selection to one
- hide aliases by default in the org list

closes #135 