### PR TITLE
partner_value_type must be an array of strings.

### DIFF
--- a/app/src/components/organizations/OrgUtils.js
+++ b/app/src/components/organizations/OrgUtils.js
@@ -105,10 +105,10 @@ export const baseOrgSchema = {
     requiresApproval: true,
   },
   partner_role_type: {
-    type: "select",
+    type: "array",
     label: "Partner role type",
     required: false,
-    multiple: false,
+    multiple: true,
     items: [
       "",
       "Bug Bounty Provider",


### PR DESCRIPTION
Lockstep with API, partner_value_type must be an array of strings.

Closes #151 