### PR TITLE
Adds json view for updating the website. 

### DIFF
--- a/app/src/components/organizations/CNAListForWebsite.vue
+++ b/app/src/components/organizations/CNAListForWebsite.vue
@@ -47,6 +47,27 @@
                 variant="outlined"
               />
 
+              <v-text-field
+                v-model="changesSinceDate"
+                class="mt-4"
+                density="comfortable"
+                hide-details
+                label="Show changes since"
+                type="date"
+                variant="outlined"
+              >
+                <template #append-inner>
+                  <v-btn
+                    v-if="changesSinceDate"
+                    aria-label="Clear changes since date"
+                    icon="mdi-close"
+                    size="x-small"
+                    variant="text"
+                    @click.stop="changesSinceDate = ''"
+                  />
+                </template>
+              </v-text-field>
+
               <div class="snapshot-meta mt-4">
                 <div class="text-caption text-medium-emphasis">Date</div>
                 <div class="text-body-2 mb-3">
@@ -57,6 +78,12 @@
                 </div>
                 <div class="text-body-2 mb-3">
                   {{ selectedSnapshot?.author ?? "—" }}
+                </div>
+                <div class="text-caption text-medium-emphasis">
+                  Comparison Baseline
+                </div>
+                <div class="text-body-2 mb-3">
+                  {{ comparisonBaselineText }}
                 </div>
                 <div class="text-caption text-medium-emphasis">
                   Highlighted Changes
@@ -114,6 +141,7 @@ const userStore = useUserStore();
 
 const dialogOpen = ref(false);
 const selectedSnapshotId = ref(null);
+const changesSinceDate = ref("");
 const copyResult = ref("");
 
 const dateFormatter = new Intl.DateTimeFormat(undefined, {
@@ -143,9 +171,16 @@ const auditSnapshots = computed(() =>
       author: authorName(entry.change_author),
       dateText: formatDate(entry.timestamp),
       label: `${labelPrefix} - ${authorName(entry.change_author)}`,
+      previousAuthor: previousEntry
+        ? authorName(previousEntry.change_author)
+        : "",
+      previousDateText: previousEntry
+        ? formatDate(previousEntry.timestamp)
+        : "",
       previousValue: previousEntry
         ? convertToCNAListForWebsite(previousEntry.audit_object)
         : null,
+      timestampMs: timestampMs(entry.timestamp),
       value,
     };
   }),
@@ -157,7 +192,10 @@ const currentSnapshot = computed(() => {
     author: "Current state",
     dateText: formatDate(props.org?.last_updated) || "Current org",
     label: "Current org",
+    previousAuthor: "",
+    previousDateText: "",
     previousValue: null,
+    timestampMs: timestampMs(props.org?.last_updated),
     value: convertToCNAListForWebsite(props.org),
   };
 });
@@ -186,10 +224,54 @@ const selectedJson = computed(() =>
   JSON.stringify(selectedSnapshot.value?.value ?? {}, null, 2),
 );
 
+const changesSinceTimestamp = computed(() =>
+  dateInputEnd(changesSinceDate.value),
+);
+
+const hasChangesSinceDate = computed(
+  () => !!changesSinceDate.value && changesSinceTimestamp.value !== null,
+);
+
+const sinceBaselineSnapshot = computed(() => {
+  if (!hasChangesSinceDate.value) return null;
+
+  return (
+    auditSnapshots.value
+      .filter(
+        (snapshot) =>
+          Number.isFinite(snapshot.timestampMs) &&
+          snapshot.timestampMs <= changesSinceTimestamp.value,
+      )
+      .at(-1) ?? null
+  );
+});
+
+const comparisonValue = computed(() => {
+  if (hasChangesSinceDate.value) {
+    return sinceBaselineSnapshot.value?.value ?? null;
+  }
+
+  return selectedSnapshot.value?.previousValue ?? null;
+});
+
+const comparisonBaselineText = computed(() => {
+  if (hasChangesSinceDate.value) {
+    const baseline = sinceBaselineSnapshot.value;
+    if (!baseline) return "No earlier snapshot";
+    return `${baseline.dateText} - ${baseline.author}`;
+  }
+
+  if (!selectedSnapshot.value?.previousValue) return "No previous snapshot";
+
+  return `${selectedSnapshot.value.previousDateText} - ${
+    selectedSnapshot.value.previousAuthor
+  }`;
+});
+
 const changedPaths = computed(() =>
   changedPathSet(
     selectedSnapshot.value?.value ?? {},
-    selectedSnapshot.value?.previousValue ?? null,
+    comparisonValue.value,
   ),
 );
 
@@ -214,6 +296,13 @@ watch(dialogOpen, () => {
   copyResult.value = "";
 });
 
+watch(changesSinceDate, (value) => {
+  copyResult.value = "";
+  if (value && snapshots.value[0]) {
+    selectedSnapshotId.value = snapshots.value[0].id;
+  }
+});
+
 onBeforeMount(async () => {
   if (auth.isSecretariat && userStore.users.length === 0) {
     await userStore.fetchUsers();
@@ -231,6 +320,23 @@ function formatDate(value) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
   return dateFormatter.format(date);
+}
+
+function timestampMs(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  const time = date.getTime();
+  return Number.isNaN(time) ? null : time;
+}
+
+function dateInputEnd(value) {
+  if (!value) return null;
+  const [year, month, day] = value.split("-").map(Number);
+  if (!year || !month || !day) return null;
+
+  const date = new Date(year, month - 1, day, 23, 59, 59, 999);
+  const time = date.getTime();
+  return Number.isNaN(time) ? null : time;
 }
 
 function stableValue(value) {

--- a/app/src/components/organizations/CNAListForWebsite.vue
+++ b/app/src/components/organizations/CNAListForWebsite.vue
@@ -1,0 +1,383 @@
+<template>
+  <section v-if="auth.isSecretariat" class="cna-list-for-website">
+    <div class="d-flex align-center justify-space-between flex-wrap ga-2">
+      <div>
+        <div class="text-subtitle-2 font-weight-bold">
+          CNA List for Website
+        </div>
+        <div class="text-caption text-medium-emphasis">
+          {{ snapshots.length }} snapshots available
+        </div>
+      </div>
+      <v-btn
+        color="primary"
+        prepend-icon="mdi-code-json"
+        size="small"
+        variant="tonal"
+        @click="dialogOpen = true"
+      >
+        View JSON
+      </v-btn>
+    </div>
+
+    <v-dialog v-model="dialogOpen" max-width="1100" scrollable>
+      <v-card>
+        <v-card-title class="d-flex align-center justify-space-between">
+          <span>CNA List for Website</span>
+          <v-btn
+            aria-label="Close"
+            icon="mdi-close"
+            size="small"
+            variant="text"
+            @click="dialogOpen = false"
+          />
+        </v-card-title>
+        <v-divider />
+        <v-card-text class="cna-list-dialog-body">
+          <v-row>
+            <v-col cols="12" md="4">
+              <v-select
+                v-model="selectedSnapshotId"
+                density="comfortable"
+                hide-details
+                item-title="label"
+                item-value="id"
+                :items="snapshotOptions"
+                label="Snapshot"
+                variant="outlined"
+              />
+
+              <div class="snapshot-meta mt-4">
+                <div class="text-caption text-medium-emphasis">Date</div>
+                <div class="text-body-2 mb-3">
+                  {{ selectedSnapshot?.dateText ?? "—" }}
+                </div>
+                <div class="text-caption text-medium-emphasis">
+                  Change Author
+                </div>
+                <div class="text-body-2 mb-3">
+                  {{ selectedSnapshot?.author ?? "—" }}
+                </div>
+                <div class="text-caption text-medium-emphasis">
+                  Highlighted Changes
+                </div>
+                <div class="text-body-2">
+                  {{ changedPaths.size }}
+                </div>
+              </div>
+            </v-col>
+
+            <v-col cols="12" md="8">
+              <pre class="cna-list-json" aria-label="CNA list JSON"><span
+                v-for="(line, i) in renderedLines"
+                :key="i"
+                class="json-line"
+                :class="{ 'json-line-changed': line.changed }"
+              >{{ line.text }}</span></pre>
+            </v-col>
+          </v-row>
+        </v-card-text>
+        <v-divider />
+        <v-card-actions>
+          <span class="text-caption text-medium-emphasis">
+            {{ copyResult }}
+          </span>
+          <v-spacer />
+          <v-btn
+            prepend-icon="mdi-content-copy"
+            variant="tonal"
+            @click="copyJson"
+          >
+            Copy JSON
+          </v-btn>
+          <v-btn variant="text" @click="dialogOpen = false">Close</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </section>
+</template>
+
+<script setup>
+import { computed, onBeforeMount, ref, watch } from "vue";
+import { useAuthStore } from "../../stores/loginAuth.js";
+import { useOrgStore } from "../../stores/organizationStore.js";
+import { useUserStore } from "../../stores/userStore.js";
+import { convertToCNAListForWebsite } from "./OrgUtils.js";
+
+const props = defineProps({
+  org: { type: Object, default: () => ({}) },
+});
+
+const auth = useAuthStore();
+const orgStore = useOrgStore();
+const userStore = useUserStore();
+
+const dialogOpen = ref(false);
+const selectedSnapshotId = ref(null);
+const copyResult = ref("");
+
+const dateFormatter = new Intl.DateTimeFormat(undefined, {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+const history = computed(() => orgStore.currentOrg?.audit?.history ?? []);
+
+const sortedHistory = computed(() =>
+  [...history.value].sort(
+    (a, b) => new Date(a.timestamp) - new Date(b.timestamp),
+  ),
+);
+
+const auditSnapshots = computed(() =>
+  sortedHistory.value.map((entry, index) => {
+    const value = convertToCNAListForWebsite(entry.audit_object);
+    const previousEntry = sortedHistory.value[index - 1];
+    const isLatest = index === sortedHistory.value.length - 1;
+    const labelPrefix = isLatest ? "Current" : formatDate(entry.timestamp);
+    return {
+      id: entry._id ?? `audit-${index}`,
+      author: authorName(entry.change_author),
+      dateText: formatDate(entry.timestamp),
+      label: `${labelPrefix} - ${authorName(entry.change_author)}`,
+      previousValue: previousEntry
+        ? convertToCNAListForWebsite(previousEntry.audit_object)
+        : null,
+      value,
+    };
+  }),
+);
+
+const currentSnapshot = computed(() => {
+  return {
+    id: "current",
+    author: "Current state",
+    dateText: formatDate(props.org?.last_updated) || "Current org",
+    label: "Current org",
+    previousValue: null,
+    value: convertToCNAListForWebsite(props.org),
+  };
+});
+
+const snapshots = computed(() =>
+  auditSnapshots.value.length
+    ? [...auditSnapshots.value].reverse()
+    : [currentSnapshot.value],
+);
+
+const snapshotOptions = computed(() =>
+  snapshots.value.map(({ id, label }) => ({ id, label })),
+);
+
+const selectedSnapshot = computed(() =>
+  (
+    snapshots.value.find(
+      (snapshot) => snapshot.id === selectedSnapshotId.value,
+    ) ??
+    snapshots.value[0] ??
+    null
+  ),
+);
+
+const selectedJson = computed(() =>
+  JSON.stringify(selectedSnapshot.value?.value ?? {}, null, 2),
+);
+
+const changedPaths = computed(() =>
+  changedPathSet(
+    selectedSnapshot.value?.value ?? {},
+    selectedSnapshot.value?.previousValue ?? null,
+  ),
+);
+
+const renderedLines = computed(() =>
+  renderJsonLines(selectedSnapshot.value?.value ?? {}).map((line) => ({
+    ...line,
+    changed: line.path ? pathChanged(changedPaths.value, line.path) : false,
+  })),
+);
+
+watch(
+  snapshots,
+  (items) => {
+    if (!items.some((item) => item.id === selectedSnapshotId.value)) {
+      selectedSnapshotId.value = items[0]?.id ?? null;
+    }
+  },
+  { immediate: true },
+);
+
+watch(dialogOpen, () => {
+  copyResult.value = "";
+});
+
+onBeforeMount(async () => {
+  if (auth.isSecretariat && userStore.users.length === 0) {
+    await userStore.fetchUsers();
+  }
+});
+
+function authorName(uuid) {
+  if (!uuid) return "—";
+  const user = userStore.users.find((u) => u.UUID === uuid);
+  return user?.username ?? uuid;
+}
+
+function formatDate(value) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return dateFormatter.format(date);
+}
+
+function stableValue(value) {
+  return JSON.stringify(value);
+}
+
+function flattenValue(value, path = "") {
+  if (value === null || typeof value !== "object") {
+    return [[path, stableValue(value)]];
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return [[path, "[]"]];
+    return value.flatMap((item, index) =>
+      flattenValue(item, `${path}[${index}]`),
+    );
+  }
+
+  const keys = Object.keys(value);
+  if (keys.length === 0) return [[path, "{}"]];
+
+  return keys.flatMap((key) =>
+    flattenValue(value[key], path ? `${path}.${key}` : key),
+  );
+}
+
+function changedPathSet(value, previousValue) {
+  const current = new Map(flattenValue(value));
+  if (!previousValue) {
+    return new Set([...current.keys()].filter(Boolean));
+  }
+
+  const previous = new Map(flattenValue(previousValue));
+  const paths = new Set([...current.keys(), ...previous.keys()]);
+  return new Set(
+    [...paths].filter((path) => current.get(path) !== previous.get(path)),
+  );
+}
+
+function pathChanged(paths, path) {
+  return [...paths].some(
+    (changedPath) =>
+      changedPath === path ||
+      changedPath.startsWith(`${path}.`) ||
+      changedPath.startsWith(`${path}[`),
+  );
+}
+
+function renderJsonLines(value, indent = 0, path = "") {
+  const space = "  ".repeat(indent);
+
+  if (value === null || typeof value !== "object") {
+    return [{ text: `${space}${JSON.stringify(value)}`, path }];
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return [{ text: `${space}[]`, path }];
+
+    const lines = [{ text: `${space}[`, path }];
+    value.forEach((item, index) => {
+      const itemPath = `${path}[${index}]`;
+      const childLines = renderJsonLines(item, indent + 1, itemPath);
+      addComma(childLines, index < value.length - 1);
+      lines.push(...childLines);
+    });
+    lines.push({ text: `${space}]`, path });
+    return lines;
+  }
+
+  const keys = Object.keys(value);
+  if (keys.length === 0) return [{ text: `${space}{}`, path }];
+
+  const lines = [{ text: `${space}{`, path }];
+  keys.forEach((key, index) => {
+    const childPath = path ? `${path}.${key}` : key;
+    const childLines = renderJsonLines(value[key], indent + 1, childPath);
+    const childValue = childLines[0].text.trimStart();
+    childLines[0] = {
+      ...childLines[0],
+      text: `${space}  ${JSON.stringify(key)}: ${childValue}`,
+      path: childPath,
+    };
+    addComma(childLines, index < keys.length - 1);
+    lines.push(...childLines);
+  });
+  lines.push({ text: `${space}}`, path });
+  return lines;
+}
+
+function addComma(lines, shouldAdd) {
+  if (!shouldAdd || lines.length === 0) return;
+  const lastIndex = lines.length - 1;
+  lines[lastIndex] = {
+    ...lines[lastIndex],
+    text: `${lines[lastIndex].text},`,
+  };
+}
+
+async function copyJson() {
+  try {
+    await navigator.clipboard.writeText(selectedJson.value);
+    copyResult.value = "Copied";
+  } catch (error) {
+    copyResult.value = "Failed to copy";
+  }
+}
+</script>
+
+<style scoped>
+.cna-list-for-website {
+  min-width: 0;
+}
+
+.cna-list-dialog-body {
+  max-height: 70vh;
+}
+
+.snapshot-meta {
+  border: 1px solid rgba(22, 46, 81, 0.14);
+  border-radius: 4px;
+  padding: 1rem;
+}
+
+.cna-list-json {
+  background: #f8fafc;
+  border: 1px solid rgba(22, 46, 81, 0.18);
+  border-radius: 4px;
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    "Courier New", monospace;
+  font-size: 0.875rem;
+  margin: 0;
+  max-height: 60vh;
+  overflow: auto;
+  padding: 1rem;
+  white-space: pre;
+}
+
+.json-line {
+  display: block;
+  margin: 0 -0.25rem;
+  padding: 0 0.25rem;
+}
+
+.json-line-changed {
+  background: #fff3cd;
+  color: #5f4100;
+  font-weight: 700;
+}
+</style>

--- a/app/src/components/organizations/OrgUtils.js
+++ b/app/src/components/organizations/OrgUtils.js
@@ -40,6 +40,154 @@ export function applyGlossaryLabels(glossaryTerms) {
   }
 }
 
+export function convertToCNAListForWebsite(org = {}) {
+  org = org ?? {};
+
+  const emptyOrg = { shortName: "n/a", organizationName: "n/a" };
+  const tlrs = {
+    "CISA TLR": {
+      shortName: "CISA",
+      organizationName:
+        "Cybersecurity and Infrastructure Security Agency (CISA)",
+    },
+    CISA: {
+      shortName: "CISA",
+      organizationName:
+        "Cybersecurity and Infrastructure Security Agency (CISA)",
+    },
+    "MITRE TLR": {
+      shortName: "mitre",
+      organizationName: "MITRE Corporation",
+    },
+    MITRE: {
+      shortName: "mitre",
+      organizationName: "MITRE Corporation",
+    },
+  };
+  const roleLabels = {
+    ADP: "ADP",
+    CNA: "CNA",
+    CNALR: "CNA-LR",
+    ROOT: "Root",
+    SECRETARIAT: "Secretariat",
+  };
+  const toArray = (value) => {
+    if (Array.isArray(value)) return value;
+    if (value === null || value === undefined || value === "") return [];
+    return [value];
+  };
+  const toValue = (value) => {
+    if (value === null || value === undefined) return "";
+    return String(value).trim();
+  };
+  const objectValue = (item, keys) => {
+    if (!item || typeof item !== "object") return null;
+    for (const key of keys) {
+      if (item[key]) return item[key];
+    }
+    return null;
+  };
+  const itemValue = (item, keys) =>
+    objectValue(item, keys) ?? (typeof item === "object" ? "" : item);
+  const uniqueBy = (items, keyFn) => {
+    const seen = new Set();
+    return items.filter((item) => {
+      const key = toValue(keyFn(item));
+      if (!key || seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  };
+  const contactInfo = org.contact_info ?? {};
+  const emailValues = uniqueBy(
+    [...toArray(org.emails), ...toArray(contactInfo.emails)],
+    (item) => itemValue(item, ["emailAddr", "email", "value"]),
+  );
+  const websiteValues = uniqueBy(
+    [...toArray(org.websites), ...toArray(contactInfo.websites)],
+    (item) => itemValue(item, ["url", "href", "website", "value"]),
+  );
+  const linkValues = uniqueBy(
+    [
+      ...toArray(org.advisory_locations),
+      ...toArray(org.vulnerability_advisory_location_for_web_scraping),
+    ],
+    (item) => itemValue(item, ["url", "href", "website", "value"]),
+  );
+  const linksFor = (values, fallbackLabel, includeLanguage = false) =>
+    values
+      .map((item) => {
+        const label = toValue(objectValue(item, ["label", "name"]));
+        const url = toValue(
+          itemValue(item, ["url", "href", "website", "value"]),
+        );
+        const link = {
+          label: label || fallbackLabel,
+          url,
+        };
+        if (includeLanguage) {
+          link.language = toValue(objectValue(item, ["language"]));
+        }
+        return link;
+      })
+      .filter((item) => item.url || item.label);
+  const disclosurePolicy = linksFor(
+    toArray(org.disclosure_policy),
+    "Policy",
+    true,
+  );
+  const advisories = linksFor(linkValues, "Advisories");
+  const authorities = toArray(org.authority).map(toValue).filter(Boolean);
+  const roles = authorities
+    .map((authority) => roleLabels[authority])
+    .filter(Boolean)
+    .map((role) => ({ helpText: "", role }));
+  const cnaTypes = toArray(org.partner_role_type)
+    .map(toValue)
+    .filter(Boolean);
+
+  return {
+    shortName: toValue(org.short_name),
+    cnaID: toValue(org.partner_number),
+    organizationName: toValue(org.long_name),
+    scope: toValue(org.charter_or_scope),
+    contact: [
+      {
+        email: emailValues.map((item) => ({
+          label: toValue(objectValue(item, ["label", "name"])) || "Email",
+          emailAddr: toValue(
+            itemValue(item, ["emailAddr", "email", "value"]),
+          ),
+        })),
+        contact: linksFor(websiteValues, "Contact"),
+        form: [],
+      },
+    ],
+    disclosurePolicy:
+      disclosurePolicy.length > 0
+        ? disclosurePolicy
+        : [{ label: "Policy", language: "", url: "" }],
+    securityAdvisories: {
+      alerts: [],
+      advisories:
+        advisories.length > 0
+          ? advisories
+          : [{ label: "Advisories", url: "" }],
+    },
+    resources: [],
+    CNA: {
+      isRoot: authorities.includes("ROOT"),
+      root: emptyOrg,
+      type: cnaTypes.length > 0 ? cnaTypes : ["N/A"],
+      TLR: tlrs[org.top_level_root] ?? emptyOrg,
+      roles: roles.length > 0 ? roles : [{ helpText: "", role: "CNA" }],
+    },
+    country: toValue(
+      toArray(org.partner_country)[0] ?? org.partner_country,
+    ),
+  };
+}
+
 // ─────────────────────────────────────────────────────────────
 // Base schema
 // ─────────────────────────────────────────────────────────────

--- a/app/src/components/organizations/OrganizationViewPage.vue
+++ b/app/src/components/organizations/OrganizationViewPage.vue
@@ -49,6 +49,9 @@
           v-for="(section, i) in visibleSections"
           :key="section.section"
         >
+          <div v-if="i > 0" class="organization-section-heading">
+            {{ section.section }}
+          </div>
           <v-row>
             <ViewField
               v-for="(overrides, key) in section.fields"
@@ -60,12 +63,11 @@
               :display="overrides.display"
             />
           </v-row>
-          <v-divider v-if="i < visibleSections.length - 1" class="my-4" />
         </template>
 
-        <v-divider class="mb-5 mt-5" />
+        <div class="organization-section-heading">Public Contact</div>
         <PublicContact :contact_info="org.contact_info" />
-        <v-divider class="mb-5 mt-5" />
+        <div class="organization-section-heading">Advisory Locations</div>
         <v-row>
           <ViewField
             v-for="(overrides, key) in advisoryLocationLayout"
@@ -83,7 +85,7 @@
             </template>
           </ViewField>
         </v-row>
-        <v-divider class="mb-5 mt-5" />
+        <div class="organization-section-heading">Record Dates</div>
         <v-row>
           <ViewField field-key="created" :data="org" :lg="6" />
           <ViewField field-key="last_updated" :data="org" :lg="6" />
@@ -103,6 +105,7 @@
     <!-- Program Info (secretariat only) -->
     <ProgramDataView
       v-if="auth.isSecretariat"
+      :org="org"
       :program_data="org.program_data"
       :review="reviewOrNull?.program_data"
     />
@@ -247,6 +250,25 @@ watch(() => props.identifier, load);
 </script>
 
 <style scoped>
+.organization-section-heading {
+  align-items: center;
+  color: #162e51;
+  display: flex;
+  font-size: 0.9375rem;
+  font-weight: 700;
+  gap: 1rem;
+  letter-spacing: 0;
+  margin: 1.75rem 0 1rem;
+  text-align: center;
+}
+
+.organization-section-heading::before,
+.organization-section-heading::after {
+  border-top: 1px solid rgba(22, 46, 81, 0.24);
+  content: "";
+  flex: 1;
+}
+
 .raw-json {
   margin: 0;
   white-space: pre-wrap;

--- a/app/src/components/organizations/program_data/ProgramData.vue
+++ b/app/src/components/organizations/program_data/ProgramData.vue
@@ -38,15 +38,19 @@
           :review="review"
         />
       </v-row>
+      <v-divider class="my-4" />
+      <CNAListForWebsite :org="org" />
     </v-card-text>
   </v-card>
 </template>
 
 <script setup>
 import ViewField from "../../ViewField.vue";
+import CNAListForWebsite from "../CNAListForWebsite.vue";
 import { useAuthStore } from "../../../stores/loginAuth";
 
 defineProps({
+  org: { type: Object, default: null },
   program_data: { type: Object, default: null },
   review: { type: Object, default: null },
 });


### PR DESCRIPTION
Add CNA website JSON audit snapshot viewer
- Add Secretariat-only dialog for generated CNA website JSON
- Show current/latest audit snapshot plus historical audit snapshots
- Resolve audit authors to usernames
- Highlight generated JSON fields changed from prior snapshot or selected baseline date
- Add calendar-based “changes since” comparison option
closes #143 